### PR TITLE
Add publish-action README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2018 GitHub, Inc. and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alpha. Action is under development and internal testing.
 ## Usage
 Action can be triggered on release creation or manually. Actual major tag update will require manual approval.
 
-Use [workflow](workflow.yml) as an example of action usage.
+Use [workflow.yml](workflow.yml) as an example of action usage.
 
 See [action.yml](action.yml) for full description of input and output fields.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Alpha. Action is under development and internal testing.
 
 ## Usage
 Action can be triggered on release creation or manually. The actual major tag update will require manual approval. 
-See [workflow.yml](./.github/workflow.yml) for usage example.
+See [release-new-action-version.yml](./.github/release-new-action-version.yml) for usage example.
 
 See [action.yml](action.yml) for a complete description of input and output fields.
 Read more about action versioning notation in [action-versioning.md](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # publish-action
 
-** Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
+**Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
 
 This actions adds reliablity to the new action version publishing process.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ This action adds reliablity to the new action version publishing and handles the
 Alpha. Action is under development and internal testing.
 
 ## Usage
-Action can be triggered on release creation or manually. Actual major tag update will require manual approval. See [workflow.yml](./.github/workflow.yml) for usage example.
+Action can be triggered on release creation or manually. Actual major tag update will require manual approval. 
+See [workflow.yml](./.github/workflow.yml) for usage example.
 
 See [action.yml](action.yml) for full description of input and output fields.
+Read more about action versioning notation in [action-versioning.md](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).
+
+To rollback release in case of customer's impact, trigger workflow manually and specify the previous stable tag.
 
 ## Conributions
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # publish-action
 
-> Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.
+**Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
 
-This actions adds reliablity to the new action version publishing process.
-
-Action handles the following processes:
+This actions adds reliablity to the new action version publishing and handles the following cases:
 - Update major tag (v1, for example) to point to the latest release (v1.2.1, for example).
 - Create major tag from the latest released tag if major tag doesn't exist 
 
@@ -12,11 +10,13 @@ Action handles the following processes:
 Alpha. Action is under development and internal testing.
 
 ## Usage
-Action can be triggered on release creation or manually. Actual major tag update will require manual approval.
-
-Use [workflow.yml](workflow.yml) as an example of action usage.
+Action can be triggered on release creation or manually. Actual major tag update will require manual approval. See [workflow.yml](./.github/workflow.yml) for usage example.
 
 See [action.yml](action.yml) for full description of input and output fields.
 
+## Conributions
+
+We don't accept contributions until action is production ready.
+
 ## License
-The scripts and documentation in this project are released under the [MIT License](LICENSE)
+The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Alpha. Action is under development and internal testing.
 
 ## Usage
 Action can be triggered on release creation or manually. The actual major tag update will require manual approval. 
-See [release-new-action-version.yml](./.github/release-new-action-version.yml) for usage example.
+See [release-new-action-version.yml](./.github/workflows/release-new-action-version.yml) for usage example.
 
 See [action.yml](action.yml) for a complete description of input and output fields.
 Read more about action versioning notation in [action-versioning.md](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).

--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 **Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
 
-This action adds reliablity to the new action version publishing and handles the following cases:
-- Update major tag (v1, for example) to point to the latest release (v1.2.1, for example).
-- Create major tag from the latest released tag if major tag doesn't exist 
+This action adds reliability to the new action versions publishing and handles the following cases:
+- Update a major tag (v1, for example) to point to the latest release (v1.2.1, for example).
+- Create a major tag from the latest released tag if a major tag doesn't exist 
 
 ## Status
 Alpha. Action is under development and internal testing.
 
 ## Usage
-Action can be triggered on release creation or manually. Actual major tag update will require manual approval. 
+Action can be triggered on release creation or manually. The actual major tag update will require manual approval. 
 See [workflow.yml](./.github/workflow.yml) for usage example.
 
-See [action.yml](action.yml) for full description of input and output fields.
+See [action.yml](action.yml) for a complete description of input and output fields.
 Read more about action versioning notation in [action-versioning.md](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).
 
-To rollback release in case of customer's impact, trigger workflow manually and specify the previous stable tag.
+To roll back a release in case of customer impact, start the workflow manually and specify the previous stable tag.
 
 ## Conributions
 
-We don't accept contributions until action is production ready.
+We don't accept contributions until the action is ready for production.
 
 ## License
 The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
 
-This actions adds reliablity to the new action version publishing and handles the following cases:
+This action adds reliablity to the new action version publishing and handles the following cases:
 - Update major tag (v1, for example) to point to the latest release (v1.2.1, for example).
 - Create major tag from the latest released tag if major tag doesn't exist 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # publish-action
 
-**Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
+> Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.
 
 This actions adds reliablity to the new action version publishing process.
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,8 @@ Alpha. Action is under development and internal testing.
 ## Usage
 Action can be triggered on release creation or manually. Actual major tag update will require manual approval.
 
-Include code snippet below to use this action in your workflow.
-```
-steps:
-  - uses: actions/checkout@v2
-  - uses: actions/publish-action@main
-    name: Push major tag to new release
-    with:
-      tag-name: ${{ github.event.release.tag_name }} # tag name from the release publish event or from the workflow_dispatch input
-```
+Use [workflow](workflow.yml) as an example of action usage.
+
 See [action.yml](action.yml) for full description of input and output fields.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # publish-action
+
+** Please note: this action is for internal usage only, we don't track issues or accept any contributions. We also do not recommend it for public or production usage.**
+
+This actions adds reliablity to the new action version publishing process.
+
+Action handles the following processes:
+- Update major tag (v1, for example) to point to the latest release (v1.2.1, for example).
+- Create major tag from the latest released tag if major tag doesn't exist 
+
+## Status
+Alpha. Action is under development and internal testing.
+
+## Usage
+Action can be triggered on release creation or manually. Actual major tag update will require manual approval.
+
+Include code snippet below to use this action in your workflow.
+```
+steps:
+  - uses: actions/checkout@v2
+  - uses: actions/publish-action@main
+    name: Push major tag to new release
+    with:
+      tag-name: ${{ github.event.release.tag_name }} # tag name from the release publish event or from the workflow_dispatch input
+```
+See [action.yml](action.yml) for full description of input and output fields.
+
+## License
+The scripts and documentation in this project are released under the [MIT License](LICENSE)


### PR DESCRIPTION
Related issue: https://github.com/actions/virtual-environments-internal/issues/2038

🐝 [RENDERED VERSION](https://github.com/akv-platform/publish-action/tree/add-action-readme) 🐝

I am adding README file that describes action, license, its status and usage (link to usage example will be added later once it is ready).